### PR TITLE
Make integration tests more resilient and other niceties

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
           GOLANGCI_LINT_VERSION=$( go list -m -f '{{.Version}}' github.com/golangci/golangci-lint )
           echo "v=$GOLANGCI_LINT_VERSION" >> "$GITHUB_OUTPUT"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           version: ${{ steps.golangci-lint-version.outputs.v }}
           skip-pkg-cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
 
 jobs:
-  test-activemq:
+  test-pinecone:
+    environment: ci  # Add this line
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,3 +18,6 @@ jobs:
 
       - name: Run all tests
         run: make test
+        env:
+          API_KEY: ${{ secrets.API_KEY }}
+          HOST_URL: ${{ secrets.HOST_URL }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: build
+name: test
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  test-activemq:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -16,5 +16,5 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Test
-        run: make test-integration GOTEST_FLAGS="-v -count=1"
+      - name: Run all tests
+        run: make test

--- a/.github/workflows/validate-generated-files.yml
+++ b/.github/workflows/validate-generated-files.yml
@@ -1,0 +1,24 @@
+name: validate-generated-files
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  validate-generated-files:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Check generated files
+        run: |
+          export PATH=$PATH:$(go env GOPATH)/bin
+          make install-tools generate
+          git diff
+          git diff --exit-code --numstat

--- a/.golangci.goheader.template
+++ b/.golangci.goheader.template
@@ -1,0 +1,13 @@
+Copyright © {{ copyright-year }} Meroxa, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,7 @@
+run:
+  timeout: 5m
+
 linters-settings:
-  gofmt:
-    simplify: false
-  govet:
-    check-shadowing: false
   nolintlint:
     allow-unused: false # report any unused nolint directives
     require-explanation: true # require an explanation for nolint directives
@@ -11,70 +10,107 @@ linters-settings:
     min-complexity: 20
   goconst:
     ignore-tests: true
+  goheader:
+    template-path: '.golangci.goheader.template'
+    values:
+      regexp:
+        copyright-year: 20[2-9]\d
+
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - dogsled
+        - gosec
+        - gocognit
+        - errcheck
+        - forcetypeassert
+        - funlen
+        - goerr113
+        - dupl
+        - prealloc
 
 linters:
   # please, do not use `enable-all`: it's deprecated and will be removed soon.
   # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
   disable-all: true
   enable:
+    - asasalint
+    - asciicheck
+    - bidichk
     - bodyclose
+    - containedctx
+    - contextcheck
+    - decorder
     # - depguard
     - dogsled
+    - dupl
+    - dupword
     - durationcheck
     - errcheck
+    - errchkjson
     - errname
-    # - errorlint
-    # - exhaustive
-    # - exhaustivestruct
+    - errorlint
+    - execinquery
+    - exhaustive
     - exportloopref
     # - forbidigo
-    # - forcetypeassert
-    # - funlen
-    # - gochecknoinits
+    - forcetypeassert
+    - funlen
+    - gci
+    - ginkgolinter
+    - gocheckcompilerdirectives
+    - gochecknoinits
+    - gocognit
     - goconst
     - gocritic
-    - gocyclo
-    # - cyclop # not interested in package complexities at the moment
-    # - godot
+    - godot
+    # - goerr113
     - gofmt
-    # - gofumpt
+    - gofumpt
     - goheader
     - goimports
-    # - revive # lots of unused parameters in the template, would be helpful for the user to keep them
-    # - gomnd
     - gomoddirectives
-    - gomodguard
     - goprintffuncname
     - gosec
     - gosimple
+    - gosmopolitan
     - govet
-    # - ifshort
+    - grouper
+    - importas
     - ineffassign
-    # - importas
-    # - lll
-    # - misspell
+    - interfacebloat
+    # - ireturn # Doesn't have correct support for generic types https://github.com/butuzov/ireturn/issues/37
+    - loggercheck
+    - maintidx
     - makezero
-    # - nakedret
-    # - nilerr
-    # - nilnil
-    # - nlreturn
+    - mirror
+    - misspell
+    - musttag
+    - nakedret
+    - nestif
+    - nilerr
+    - nilnil
     - noctx
     - nolintlint
-    # - paralleltest
+    - nosprintfhostport
+    - prealloc
     - predeclared
-    # - rowserrcheck
+    - promlinter
+    - reassign
+    - revive
+    - rowserrcheck
+    - sqlclosecheck
     - staticcheck
     - stylecheck
-    # - sqlclosecheck
-    # - tagliatelle
-    # - tenv
+    - tenv
+    - testableexamples
     # - thelper
-    # - tparallel
-    - typecheck
     - unconvert
-    # - unparam
+    - unparam
     - unused
-    # - wastedassign
+    - usestdlibvars
+    - wastedassign
     - whitespace
-    # - wrapcheck
-    # - wsl
+    - wrapcheck
+    - zerologlint

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,7 @@ build:
 	go build -ldflags "-X 'github.com/conduitio/conduit-connector-pinecone.version=${VERSION}'" -o conduit-connector-pinecone cmd/connector/main.go
 
 test:
-	go test $(GOTEST_FLAGS) -race ./...
-
-test-integration:
-	# run required docker containers, execute integration tests, stop containers after tests
-	docker compose -f test/docker-compose.yml up -d
-	go test $(GOTEST_FLAGS) -v -race ./...; ret=$$?; \
-		docker compose -f test/docker-compose.yml down; \
-		exit $$ret
+	go test -v -race ./...
 
 generate:
 	go generate ./...

--- a/cmd/connector/main.go
+++ b/cmd/connector/main.go
@@ -1,9 +1,22 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (
-	sdk "github.com/conduitio/conduit-connector-sdk"
-
 	pinecone "github.com/conduitio-labs/conduit-connector-pinecone"
+	sdk "github.com/conduitio/conduit-connector-sdk"
 )
 
 func main() {

--- a/connector.go
+++ b/connector.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package pinecone
 
 import (

--- a/destination.go
+++ b/destination.go
@@ -12,7 +12,6 @@ type Destination struct {
 	sdk.UnimplementedDestination
 
 	config DestinationConfig
-	client *pineconeClient
 	writer *Writer
 }
 
@@ -35,6 +34,10 @@ func NewDestination() sdk.Destination {
 	return sdk.DestinationWithMiddleware(&Destination{}, sdk.DefaultDestinationMiddleware()...)
 }
 
+func newDestination() *Destination {
+	return &Destination{}
+}
+
 func (d *Destination) Configure(ctx context.Context, cfg map[string]string) error {
 	if err := sdk.Util.ParseConfig(cfg, &d.config); err != nil {
 		return fmt.Errorf("invalid config: %w", err)
@@ -50,8 +53,6 @@ func (d *Destination) Open(ctx context.Context) error {
 		return fmt.Errorf("error creating a new writer: %w", err)
 	}
 	d.writer = newWriter
-
-	d.client = newPineconeClient(d.config)
 
 	sdk.Logger(ctx).Info().Msg("created pinecone destination")
 
@@ -69,7 +70,7 @@ func (d *Destination) Write(ctx context.Context, records []sdk.Record) (int, err
 		if err != nil {
 			return i, fmt.Errorf("route %s: %w", record.Operation.String(), err)
 		}
-		sdk.Logger(ctx).Trace().Msg("wrote record")
+		sdk.Logger(ctx).Trace().Msgf("wrote record op %s", record.Operation.String())
 	}
 
 	return len(records), nil

--- a/destination.go
+++ b/destination.go
@@ -67,12 +67,11 @@ func (d *Destination) Configure(ctx context.Context, cfg map[string]string) erro
 	return nil
 }
 
-func (d *Destination) Open(ctx context.Context) error {
-	newWriter, err := NewWriter(ctx, d.config)
+func (d *Destination) Open(ctx context.Context) (err error) {
+	d.writer, err = NewWriter(ctx, d.config)
 	if err != nil {
 		return fmt.Errorf("error creating a new writer: %w", err)
 	}
-	d.writer = newWriter
 
 	sdk.Logger(ctx).Info().Msg("created pinecone destination")
 

--- a/destination.go
+++ b/destination.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package pinecone
 
 //go:generate paramgen -output=paramgen_dest.go DestinationConfig
@@ -5,6 +19,7 @@ package pinecone
 import (
 	"context"
 	"fmt"
+
 	sdk "github.com/conduitio/conduit-connector-sdk"
 )
 

--- a/destination.go
+++ b/destination.go
@@ -16,17 +16,22 @@ type Destination struct {
 }
 
 type DestinationConfig struct {
-	// PineconeAPIKey is the API Key for authenticating with Pinecone.
-	PineconeAPIKey string `json:"pinecone.apiKey" validate:"required"`
+	// APIKey is the API Key for authenticating with Pinecone.
+	APIKey string `json:"pinecone.apiKey" validate:"required"`
 
-	// PineconeHost is the Pinecone index host URL
-	PineconeHost string `json:"pinecone.host" validate:"required"`
+	// Host is the Pinecone index host URL
+	Host string `json:"pinecone.host" validate:"required"`
+
+	// Namespace is the Pinecone's index namespace. Defaults to the empty
+	// namespace.
+	Namespace string `json:"pinecone.namespace"`
 }
 
 func (d DestinationConfig) toMap() map[string]string {
 	return map[string]string{
-		"pinecone.apiKey": d.PineconeAPIKey,
-		"pinecone.host":   d.PineconeHost,
+		"pinecone.apiKey":    d.APIKey,
+		"pinecone.host":      d.Host,
+		"pinecone.namespace": d.Namespace,
 	}
 }
 

--- a/destination_test.go
+++ b/destination_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package pinecone
 
 import (
@@ -36,7 +50,7 @@ func TestDestination_NamespaceSet(t *testing.T) {
 
 	err = dest.Open(ctx)
 	is.NoErr(err)
-	defer teardown(is, ctx, dest)
+	defer teardown(ctx, is, dest)
 
 	is.Equal(dest.writer.index.Namespace, "test-namespace")
 }
@@ -52,7 +66,7 @@ func TestDestination_Integration_WriteDelete(t *testing.T) {
 
 	err = dest.Open(ctx)
 	is.NoErr(err)
-	defer teardown(is, ctx, dest)
+	defer teardown(ctx, is, dest)
 
 	id := uuid.NewString()
 	position := sdk.Position(fmt.Sprintf("pos-%v", id))
@@ -62,7 +76,7 @@ func TestDestination_Integration_WriteDelete(t *testing.T) {
 	}
 
 	vecsToBeWritten := recordPayload{
-		Id:     id,
+		ID:     id,
 		Values: []float32{1, 2},
 	}
 
@@ -73,35 +87,35 @@ func TestDestination_Integration_WriteDelete(t *testing.T) {
 	_, err = dest.Write(ctx, []sdk.Record{rec})
 	is.NoErr(err)
 
-	assertWrittenRecordIndex(t, is, ctx, dest.writer.index, id, vecsToBeWritten)
+	assertWrittenRecordIndex(ctx, t, is, dest.writer.index, id, vecsToBeWritten)
 
 	rec = sdk.Util.Source.NewRecordDelete(position, metadata, sdk.RawData(id))
 	_, err = dest.Write(ctx, []sdk.Record{rec})
+	is.NoErr(err)
 
-	assertDeletedRecordIndex(t, is, ctx, dest.writer.index, id)
+	assertDeletedRecordIndex(ctx, t, is, dest.writer.index, id)
 
 	deleteAllRecords(is, dest.writer.index)
 }
 
-const MAX_RETRIES = 3
+const maxRetries = 3
 
 func waitTime(i int) time.Duration {
 	wait := math.Pow(2, float64(i))
 	return time.Duration(wait) * time.Second
 }
 
-func assertWrittenRecordIndex(t *testing.T, is *is.I, ctx context.Context, index *pinecone.IndexConnection, id string, writtenVecs recordPayload) {
-
+func assertWrittenRecordIndex(ctx context.Context, t *testing.T, is *is.I, index *pinecone.IndexConnection, id string, writtenVecs recordPayload) {
 	// Pinecone writes appear to be asynchronous. At the very least, in the current free tier serverless
 	// configuration that I've tested, pinecone writes occurred slightly after the RPC call
 	// returned data. Therefore, the following retry logic is needed to make tests more robust
-	for i := 1; i <= MAX_RETRIES; i++ {
+	for i := 1; i <= maxRetries; i++ {
 		res, err := index.FetchVectors(&ctx, []string{id})
 		is.NoErr(err)
 
 		vec, ok := res.Vectors[id]
 		if !ok {
-			if i == MAX_RETRIES {
+			if i == maxRetries {
 				is.Fail() // vector was not written
 			} else {
 				wait := waitTime(i)
@@ -116,15 +130,15 @@ func assertWrittenRecordIndex(t *testing.T, is *is.I, ctx context.Context, index
 	}
 }
 
-func assertDeletedRecordIndex(t *testing.T, is *is.I, ctx context.Context, index *pinecone.IndexConnection, id string) {
+func assertDeletedRecordIndex(ctx context.Context, t *testing.T, is *is.I, index *pinecone.IndexConnection, id string) {
 	// same as assertWrittenRecordIndex, we need the retry for robustness
-	for i := 0; i <= MAX_RETRIES; i++ {
+	for i := 0; i <= maxRetries; i++ {
 		res, err := index.FetchVectors(&ctx, []string{id})
 		is.NoErr(err)
 
 		_, ok := res.Vectors[id]
 		if ok {
-			if i == MAX_RETRIES {
+			if i == maxRetries {
 				is.Fail() // vector found, not properly deleted
 			} else {
 				wait := waitTime(i)
@@ -152,7 +166,7 @@ type connectorResource interface {
 	Teardown(ctx context.Context) error
 }
 
-func teardown(is *is.I, ctx context.Context, resource connectorResource) {
+func teardown(ctx context.Context, is *is.I, resource connectorResource) {
 	err := resource.Teardown(ctx)
 	is.NoErr(err)
 }

--- a/destination_test.go
+++ b/destination_test.go
@@ -30,16 +30,26 @@ import (
 	"github.com/pinecone-io/go-pinecone/pinecone"
 )
 
-func destConfigFromEnv() DestinationConfig {
+func destConfigFromEnv(t *testing.T) DestinationConfig {
 	return DestinationConfig{
-		APIKey: os.Getenv("API_KEY"),
-		Host:   os.Getenv("HOST_URL"),
+		APIKey: requiredEnv(t, "API_KEY"),
+		Host:   requiredEnv(t, "HOST_URL"),
 	}
+}
+
+func requiredEnv(t *testing.T, key string) string {
+	val := os.Getenv(key)
+	if val == "" {
+		t.Fatalf("env var %v unset", key)
+	}
+
+	return val
 }
 
 func TestDestination_NamespaceSet(t *testing.T) {
 	ctx := context.Background()
-	destCfg := destConfigFromEnv()
+	destCfg := destConfigFromEnv(t)
+	// we use the default namespace on all other tests, so it's correct to set it here
 	destCfg.Namespace = "test-namespace"
 
 	is := is.New(t)
@@ -57,7 +67,7 @@ func TestDestination_NamespaceSet(t *testing.T) {
 
 func TestDestination_Integration_WriteDelete(t *testing.T) {
 	ctx := context.Background()
-	destCfg := destConfigFromEnv()
+	destCfg := destConfigFromEnv(t)
 	is := is.New(t)
 	dest := newDestination()
 

--- a/destination_test.go
+++ b/destination_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"testing"
+	"time"
 
 	sdk "github.com/conduitio/conduit-connector-sdk"
 	"github.com/google/uuid"
@@ -22,13 +22,18 @@ func destConfigFromEnv() DestinationConfig {
 	}
 }
 
-func TestWriter(t *testing.T) {
-	is := is.New(t)
-	cfg := destConfigFromEnv()
+func TestDestination_Integration_WriteDelete(t *testing.T) {
 	ctx := context.Background()
+	destCfg := destConfigFromEnv()
+	is := is.New(t)
+	dest := newDestination()
 
-	writer, err := NewWriter(context.Background(), cfg)
+	err := dest.Configure(ctx, destCfg.toMap())
 	is.NoErr(err)
+
+	err = dest.Open(ctx)
+	is.NoErr(err)
+	defer teardown(is, ctx, dest)
 
 	id := uuid.NewString()
 	position := sdk.Position(fmt.Sprintf("pos-%v", id))
@@ -46,135 +51,64 @@ func TestWriter(t *testing.T) {
 	is.NoErr(err)
 
 	rec := sdk.Util.Source.NewRecordCreate(position, metadata, sdk.RawData(id), sdk.RawData(payload))
-
-	err = writer.Upsert(ctx, rec)
-	is.NoErr(err)
-
-	recs, err := writer.index.FetchVectors(&ctx, []string{id})
-	is.NoErr(err)
-
-	fmt.Println(recs.Vectors)
-}
-
-func TestDestination_Integration_WriteDelete(t *testing.T) {
-	ctx := context.Background()
-	destCfg := destConfigFromEnv()
-	is := is.New(t)
-	index := createIndex(is)
-
-	dest := NewDestination()
-
-	err := dest.Configure(ctx, destCfg.toMap())
-	is.NoErr(err)
-
-	err = dest.Open(ctx)
-	is.NoErr(err)
-	defer teardown(is, ctx, dest)
-
-	id := uuid.NewString()
-	position := sdk.Position(fmt.Sprintf("pos-%v", id))
-	metadata := map[string]string{
-		"pinecone.prop1": "val1",
-		"pinecone.prop2": "val2",
-	}
-
-	vecsToBeWritten := recordPayload{
-		Id:           id,
-		Values:       []float32{1, 2},
-		SparseValues: sparseValues{},
-	}
-
-	payload, err := json.Marshal(vecsToBeWritten)
-	is.NoErr(err)
-
-	rec := sdk.Util.Source.NewRecordCreate(position, metadata, sdk.RawData(id), sdk.RawData(payload))
-
 	_, err = dest.Write(ctx, []sdk.Record{rec})
 	is.NoErr(err)
-	// defer deleteRecord(is, index, id)
 
-	assertWrittenRecordIndex(is, ctx, index, id, vecsToBeWritten)
+	assertWrittenRecordIndex(is, ctx, dest.writer.index, id, vecsToBeWritten)
 
 	rec = sdk.Util.Source.NewRecordDelete(position, metadata, sdk.RawData(id))
 	_, err = dest.Write(ctx, []sdk.Record{rec})
 
-	assertDeletedRecordIndex(is, ctx, index, id)
-}
+	assertDeletedRecordIndex(is, ctx, dest.writer.index, id)
 
-func createIndex(is *is.I) *pinecone.IndexConnection {
-	destCfg := destConfigFromEnv()
-
-	client, err := pinecone.NewClient(pinecone.NewClientParams{
-		ApiKey: destCfg.PineconeAPIKey,
-	})
-	is.NoErr(err)
-
-	index, err := client.Index(destCfg.PineconeHost)
-	is.NoErr(err)
-
-	// index.Namespace = "default"
-
-	return index
-}
-
-func assertWrittenRecordClient(is *is.I, ctx context.Context, client *pineconeClient, id string, writtenVecs UpsertBody) {
-	vectors, err := client.fetchVectors([]string{id})
-	is.NoErr(err)
-
-	vec, ok := vectors[id]
-	if !ok {
-		is.Fail() // vector not found
-	}
-
-	is.Equal(vec.Values, writtenVecs.Vectors[0].Values)
-	// is.Equal(vec.SparseValues.Indices, recVecValues.SparseValues.Indices)
-	// is.Equal(vec.SparseValues.Values, recVecValues.SparseValues.Values)
+	deleteAllRecords(is, dest.writer.index)
 }
 
 func assertWrittenRecordIndex(is *is.I, ctx context.Context, index *pinecone.IndexConnection, id string, writtenVecs recordPayload) {
-	res, err := index.FetchVectors(&ctx, []string{id})
-	is.NoErr(err)
+	for i := 0; i < 3; i++ {
+		res, err := index.FetchVectors(&ctx, []string{id})
+		is.NoErr(err)
 
-	vec, ok := res.Vectors[id]
-	if !ok {
-		is.Fail() // vector not found
-	}
+		vec, ok := res.Vectors[id]
+		if !ok {
+			if i == 2 {
+				is.Fail() // vector was not written
+			} else {
+				time.Sleep(time.Duration(i) * time.Second)
+				continue
+			}
+		}
 
-	is.Equal(vec.Values, writtenVecs.Values)
-	// is.Equal(vec.SparseValues.Indices, recVecValues.SparseValues.Indices)
-	// is.Equal(vec.SparseValues.Values, recVecValues.SparseValues.Values)
-}
-
-func assertDeletedRecordClient(is *is.I, ctx context.Context, client *pineconeClient, id string) {
-	vectors, err := client.fetchVectors([]string{id})
-	is.NoErr(err)
-
-	_, ok := vectors[id]
-	if ok {
-		is.Fail() // vector found, not properly deleted
+		is.Equal(vec.Values, writtenVecs.Values)
+		break
 	}
 }
 
 func assertDeletedRecordIndex(is *is.I, ctx context.Context, index *pinecone.IndexConnection, id string) {
-	res, err := index.FetchVectors(&ctx, []string{id})
-	is.NoErr(err)
+	for i := 0; i < 3; i++ {
+		res, err := index.FetchVectors(&ctx, []string{id})
+		is.NoErr(err)
 
-	_, ok := res.Vectors[id]
-	if ok {
-		is.Fail() // vector found, not properly deleted
+		_, ok := res.Vectors[id]
+		if ok {
+			if i == 2 {
+				is.Fail() // vector found, not properly deleted
+			} else {
+				time.Sleep(time.Duration(i) * time.Second)
+				continue
+			}
+		}
 	}
 }
 
-func deleteRecord(is *is.I, index *pinecone.IndexConnection, id string) {
+func deleteAllRecords(is *is.I, index *pinecone.IndexConnection) {
 	ctx := context.Background()
-	err := index.DeleteVectorsById(&ctx, []string{id})
+	err := index.DeleteAllVectorsInNamespace(&ctx)
 	is.NoErr(err)
 }
 
 func TestMain(t *testing.M) {
-	if err := godotenv.Load(); err != nil {
-		log.Fatal("error loading environment variables")
-	}
+	godotenv.Load()
 
 	t.Run()
 }

--- a/destination_test.go
+++ b/destination_test.go
@@ -98,7 +98,7 @@ func TestDestination_Integration_WriteDelete(t *testing.T) {
 	deleteAllRecords(is, dest.writer.index)
 }
 
-const maxRetries = 3
+const maxRetries = 4
 
 func waitTime(i int) time.Duration {
 	wait := math.Pow(2, float64(i))

--- a/destination_test.go
+++ b/destination_test.go
@@ -78,6 +78,10 @@ func TestDestination_Integration_WriteDelete(t *testing.T) {
 	vecsToBeWritten := recordPayload{
 		ID:     id,
 		Values: []float32{1, 2},
+		SparseValues: sparseValues{
+			Indices: []uint32{3, 5},
+			Values:  []float32{0.5, 0.3},
+		},
 	}
 
 	payload, err := json.Marshal(vecsToBeWritten)
@@ -126,6 +130,8 @@ func assertWrittenRecordIndex(ctx context.Context, t *testing.T, is *is.I, index
 		}
 
 		is.Equal(vec.Values, writtenVecs.Values)
+		is.Equal(vec.SparseValues.Values, writtenVecs.SparseValues.Values)
+		is.Equal(vec.SparseValues.Indices, writtenVecs.SparseValues.Indices)
 		break
 	}
 }

--- a/paramgen_dest.go
+++ b/paramgen_dest.go
@@ -25,5 +25,11 @@ func (DestinationConfig) Parameters() map[string]sdk.Parameter {
 				sdk.ValidationRequired{},
 			},
 		},
+		"pinecone.namespace": {
+			Default:     "",
+			Description: "pinecone.namespace is the Pinecone's index namespace. Defaults to the empty namespace.",
+			Type:        sdk.ParameterTypeString,
+			Validations: []sdk.Validation{},
+		},
 	}
 }

--- a/paramgen_dest.go
+++ b/paramgen_dest.go
@@ -17,9 +17,9 @@ func (DestinationConfig) Parameters() map[string]sdk.Parameter {
 				sdk.ValidationRequired{},
 			},
 		},
-		"pinecone.hostURL": {
+		"pinecone.host": {
 			Default:     "",
-			Description: "pinecone.hostURL is the Pinecone index host URL",
+			Description: "pinecone.host is the Pinecone index host URL",
 			Type:        sdk.ParameterTypeString,
 			Validations: []sdk.Validation{
 				sdk.ValidationRequired{},

--- a/spec.go
+++ b/spec.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package pinecone
 
 import (

--- a/tools.go
+++ b/tools.go
@@ -17,5 +17,6 @@
 package pinecone
 
 import (
+	_ "github.com/conduitio/conduit-connector-sdk/cmd/paramgen"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 )

--- a/writer.go
+++ b/writer.go
@@ -1,208 +1,16 @@
 package pinecone
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
-	"net/url"
 	"strings"
-	"time"
 
 	sdk "github.com/conduitio/conduit-connector-sdk"
 	"github.com/pinecone-io/go-pinecone/pinecone"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/structpb"
 )
-
-type pineconeClient struct {
-	host   string
-	apikey string
-	client *http.Client
-}
-
-func newPineconeClient(config DestinationConfig) *pineconeClient {
-	return &pineconeClient{
-		host:   config.PineconeHost,
-		apikey: config.PineconeAPIKey,
-		client: &http.Client{Timeout: 10 * time.Second},
-	}
-}
-
-func (pc pineconeClient) newRequest(method, path string, body any) (*http.Request, error) {
-	bs, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-
-	buf := bytes.NewBuffer(bs)
-	url := fmt.Sprintf("https://%s%s", pc.host, path)
-	fmt.Println("url", url)
-	fmt.Println("buf", buf.String())
-	req, err := http.NewRequest(method, url, buf)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Api-Key", pc.apikey)
-	req.Header.Set("Content-Type", "application/json")
-
-	return req, nil
-}
-
-func (pc pineconeClient) newGet(path string) (*http.Request, error) {
-	url := fmt.Sprintf("https://%s%s", pc.host, path)
-	fmt.Println("url", url)
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Api-Key", pc.apikey)
-
-	return req, nil
-}
-
-type Vector struct {
-	Id     string    `json:"id"`
-	Values []float32 `json:"values"`
-}
-
-type UpsertBody struct {
-	Namespace string   `json:"namespace"`
-	Vectors   []Vector `json:"vectors"`
-}
-
-func (pc pineconeClient) Upsert(ctx context.Context, rec sdk.Record) error {
-	var body UpsertBody
-	err := json.Unmarshal(rec.Payload.After.Bytes(), &body)
-	if err != nil {
-		return err
-	}
-
-	req, err := pc.newRequest("POST", "/vectors/upsert", body)
-	if err != nil {
-		return err
-	}
-
-	res, err := pc.client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode >= 400 {
-		bs, err := io.ReadAll(res.Body)
-		if err != nil {
-			return err
-		}
-
-		return fmt.Errorf("bad status code %v, payload %s", res.StatusCode, string(bs))
-	}
-
-	return nil
-}
-
-type DeleteBody struct {
-	Ids       []string `json:"ids"`
-	Namespace string   `json:"namespace,omitempty"`
-}
-
-func (pc pineconeClient) Delete(ctx context.Context, rec sdk.Record) error {
-	payload, err := parseRecordPayload(rec.Payload)
-	if err != nil {
-		return err
-	}
-
-	body := DeleteBody{
-		Ids: []string{payload.Id},
-	}
-
-	req, err := pc.newRequest("POST", "/vectors/delete", body)
-	if err != nil {
-		return err
-	}
-
-	res, err := pc.client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode >= 400 {
-		bs, err := io.ReadAll(res.Body)
-		if err != nil {
-			return err
-		}
-
-		return fmt.Errorf("bad status code %v, payload %s", res.StatusCode, string(bs))
-	}
-
-	return nil
-}
-
-func (pc pineconeClient) fetchVectors(ids []string) (map[string]Vector, error) {
-	query := make(url.Values)
-	idsVal := strings.Join(ids, ",")
-	query.Set("ids", idsVal)
-
-	req, err := pc.newGet("/vectors/fetch?" + query.Encode())
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := pc.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer res.Body.Close()
-
-	bs, err := io.ReadAll(res.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	fmt.Println("payload", string(bs))
-
-	var payload struct {
-		Vectors map[string]Vector `json:"vectors"`
-	}
-
-	if err := json.Unmarshal(bs, &payload); err != nil {
-		return nil, fmt.Errorf("unmarshal error: %w", err)
-	}
-
-	return payload.Vectors, nil
-}
-
-func (pc pineconeClient) deleteVector(ids []string) error {
-	// how can I refactor this code so that I don't have to use io.Readall? I think there's some io utilities that I can use so that I don't have to use io.ReadAll
-	req, err := pc.newRequest("POST", "/vectors/delete", map[string]any{
-		"ids": ids,
-	})
-	if err != nil {
-		return err
-	}
-
-	res, err := pc.client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode >= 400 {
-		bs, err := io.ReadAll(res.Body)
-		if err != nil {
-			return err
-		}
-
-		return fmt.Errorf("bad status code %v, payload %s", res.StatusCode, string(bs))
-	}
-
-	return nil
-}
 
 // Writer implements a writer logic for Sap hana destination.
 type Writer struct {
@@ -226,7 +34,7 @@ func NewWriter(ctx context.Context, config DestinationConfig) (*Writer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error establishing index connection: %v", err)
 	}
-	sdk.Logger(ctx).Info().Msgf("created pinecone index")
+	sdk.Logger(ctx).Info().Msg("created pinecone index")
 
 	writer := &Writer{
 		client: client,
@@ -259,20 +67,22 @@ func (w *Writer) Upsert(ctx context.Context, record sdk.Record) error {
 	if err != nil {
 		return fmt.Errorf("error upserting record: %v ", err)
 	}
+	sdk.Logger(ctx).Trace().Msgf("upserted record id %s", id)
 
 	return nil
 }
 
 // Delete deletes records by a key.
 func (w *Writer) Delete(ctx context.Context, record sdk.Record) error {
-	ids := []string{recordID(record.Key)}
+	id := recordID(record.Key)
+	ids := []string{id}
 
 	err := w.index.DeleteVectorsById(&ctx, ids)
 	if err != nil {
 		return fmt.Errorf("error deleting record: %v", err)
 	}
+	sdk.Logger(ctx).Trace().Msgf("deleted record %v", id)
 
-	sdk.Logger(ctx).Trace().Msgf("deleted record %v", ids)
 	return nil
 }
 
@@ -293,6 +103,7 @@ type recordPayload struct {
 	Id           string       `json:"id"`
 	Values       []float32    `json:"values"`
 	SparseValues sparseValues `json:"sparse_values,omitempty"`
+	Namespace    string       `json:"namespace"`
 }
 
 func (r recordPayload) PineconeSparseValues() *pinecone.SparseValues {

--- a/writer.go
+++ b/writer.go
@@ -1,10 +1,15 @@
 package pinecone
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"strings"
+	"time"
 
 	sdk "github.com/conduitio/conduit-connector-sdk"
 	"github.com/pinecone-io/go-pinecone/pinecone"
@@ -12,32 +17,226 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+type pineconeClient struct {
+	host   string
+	apikey string
+	client *http.Client
+}
+
+func newPineconeClient(config DestinationConfig) *pineconeClient {
+	return &pineconeClient{
+		host:   config.PineconeHost,
+		apikey: config.PineconeAPIKey,
+		client: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (pc pineconeClient) newRequest(method, path string, body any) (*http.Request, error) {
+	bs, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	buf := bytes.NewBuffer(bs)
+	url := fmt.Sprintf("https://%s%s", pc.host, path)
+	fmt.Println("url", url)
+	fmt.Println("buf", buf.String())
+	req, err := http.NewRequest(method, url, buf)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Api-Key", pc.apikey)
+	req.Header.Set("Content-Type", "application/json")
+
+	return req, nil
+}
+
+func (pc pineconeClient) newGet(path string) (*http.Request, error) {
+	url := fmt.Sprintf("https://%s%s", pc.host, path)
+	fmt.Println("url", url)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Api-Key", pc.apikey)
+
+	return req, nil
+}
+
+type Vector struct {
+	Id     string    `json:"id"`
+	Values []float32 `json:"values"`
+}
+
+type UpsertBody struct {
+	Namespace string   `json:"namespace"`
+	Vectors   []Vector `json:"vectors"`
+}
+
+func (pc pineconeClient) Upsert(ctx context.Context, rec sdk.Record) error {
+	var body UpsertBody
+	err := json.Unmarshal(rec.Payload.After.Bytes(), &body)
+	if err != nil {
+		return err
+	}
+
+	req, err := pc.newRequest("POST", "/vectors/upsert", body)
+	if err != nil {
+		return err
+	}
+
+	res, err := pc.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode >= 400 {
+		bs, err := io.ReadAll(res.Body)
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("bad status code %v, payload %s", res.StatusCode, string(bs))
+	}
+
+	return nil
+}
+
+type DeleteBody struct {
+	Ids       []string `json:"ids"`
+	Namespace string   `json:"namespace,omitempty"`
+}
+
+func (pc pineconeClient) Delete(ctx context.Context, rec sdk.Record) error {
+	payload, err := parseRecordPayload(rec.Payload)
+	if err != nil {
+		return err
+	}
+
+	body := DeleteBody{
+		Ids: []string{payload.Id},
+	}
+
+	req, err := pc.newRequest("POST", "/vectors/delete", body)
+	if err != nil {
+		return err
+	}
+
+	res, err := pc.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode >= 400 {
+		bs, err := io.ReadAll(res.Body)
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("bad status code %v, payload %s", res.StatusCode, string(bs))
+	}
+
+	return nil
+}
+
+func (pc pineconeClient) fetchVectors(ids []string) (map[string]Vector, error) {
+	query := make(url.Values)
+	idsVal := strings.Join(ids, ",")
+	query.Set("ids", idsVal)
+
+	req, err := pc.newGet("/vectors/fetch?" + query.Encode())
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := pc.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	bs, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Println("payload", string(bs))
+
+	var payload struct {
+		Vectors map[string]Vector `json:"vectors"`
+	}
+
+	if err := json.Unmarshal(bs, &payload); err != nil {
+		return nil, fmt.Errorf("unmarshal error: %w", err)
+	}
+
+	return payload.Vectors, nil
+}
+
+func (pc pineconeClient) deleteVector(ids []string) error {
+	// how can I refactor this code so that I don't have to use io.Readall? I think there's some io utilities that I can use so that I don't have to use io.ReadAll
+	req, err := pc.newRequest("POST", "/vectors/delete", map[string]any{
+		"ids": ids,
+	})
+	if err != nil {
+		return err
+	}
+
+	res, err := pc.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode >= 400 {
+		bs, err := io.ReadAll(res.Body)
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("bad status code %v, payload %s", res.StatusCode, string(bs))
+	}
+
+	return nil
+}
+
 // Writer implements a writer logic for Sap hana destination.
 type Writer struct {
 	client *pinecone.Client
 	index  *pinecone.IndexConnection
 }
 
-// NewWriter New creates new instance of the Writer.
 func NewWriter(ctx context.Context, config DestinationConfig) (*Writer, error) {
-	sdk.Logger(ctx).Trace().Msg("Creating new writer.")
-
-	sdk.Logger(ctx).Error().Msgf("API: %v, INDEX:%v", config.PineconeAPIKey, config.PineconeHostURL)
-
-	pineconeClient, indexConnection, err := NewPineconeClient(ctx, config)
+	client, err := pinecone.NewClient(pinecone.NewClientParams{
+		ApiKey: config.PineconeAPIKey,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create pinecone pineconeClient: %v", err)
+		return nil, fmt.Errorf("error creating Pinecone client: %v", err)
 	}
+	sdk.Logger(ctx).Info().Msg("created pinecone client")
+
+	// index urls should have their protocol trimmed
+	host := strings.TrimPrefix(config.PineconeHost, "https://")
+
+	index, err := client.Index(host)
+	if err != nil {
+		return nil, fmt.Errorf("error establishing index connection: %v", err)
+	}
+	sdk.Logger(ctx).Info().Msgf("created pinecone index")
 
 	writer := &Writer{
-		client: pineconeClient,
-		index:  indexConnection,
+		client: client,
+		index:  index,
 	}
 	return writer, nil
 }
 
 func (w *Writer) Upsert(ctx context.Context, record sdk.Record) error {
-	ID := recordID(record.Key)
+	id := recordID(record.Key)
 
 	payload, err := parseRecordPayload(record.Payload)
 	if err != nil {
@@ -49,34 +248,31 @@ func (w *Writer) Upsert(ctx context.Context, record sdk.Record) error {
 		return fmt.Errorf("error getting metadata: %v", err)
 	}
 
-	sdk.Logger(ctx).Error().Msgf("metadata: %v", metadata)
+	vec := &pinecone.Vector{
+		Id:     id,
+		Values: payload.Values,
+		// SparseValues: payload.PineconeSparseValues(),
+		Metadata: metadata,
+	}
 
-	vector := []*pinecone.Vector{{
-		Id:           ID,
-		Values:       payload.Values,
-		SparseValues: payload.PineconeSparseValues(),
-		Metadata:     metadata,
-	}}
-
-	_, err = w.index.UpsertVectors(&ctx, vector)
+	_, err = w.index.UpsertVectors(&ctx, []*pinecone.Vector{vec})
 	if err != nil {
 		return fmt.Errorf("error upserting record: %v ", err)
 	}
 
-	sdk.Logger(ctx).Trace().Msg("upserted record")
 	return nil
 }
 
 // Delete deletes records by a key.
 func (w *Writer) Delete(ctx context.Context, record sdk.Record) error {
-	ID := []string{recordID(record.Key)}
+	ids := []string{recordID(record.Key)}
 
-	err := w.index.DeleteVectorsById(&ctx, ID)
+	err := w.index.DeleteVectorsById(&ctx, ids)
 	if err != nil {
-		return fmt.Errorf("\n error deleting record: %v ", err)
+		return fmt.Errorf("error deleting record: %v", err)
 	}
 
-	sdk.Logger(ctx).Trace().Msg("Successful record delete.")
+	sdk.Logger(ctx).Trace().Msgf("deleted record %v", ids)
 	return nil
 }
 
@@ -84,49 +280,30 @@ func (w *Writer) Close() error {
 	return w.index.Close()
 }
 
-// NewPineconeClient takes the Pinecone Index URL string in Config and splits into respective parts to establish a
-// connection
-func NewPineconeClient(ctx context.Context, config DestinationConfig) (*pinecone.Client, *pinecone.IndexConnection, error) {
-	sdk.Logger(ctx).Trace().Msg("Creating a Pinecone Client.")
-
-	client, err := pinecone.NewClient(pinecone.NewClientParams{
-		ApiKey: config.PineconeAPIKey,
-	})
-	if err != nil {
-		return nil, nil, fmt.Errorf("error creating Pinecone client: %v", err)
-	}
-	sdk.Logger(ctx).Info().Msg("created pinecone client")
-
-	// index urls should have their protocol trimmed
-	hostURL := strings.TrimPrefix(config.PineconeHostURL, "https://")
-
-	index, err := client.Index(hostURL)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error establishing index connection: %v", err)
-	}
-	sdk.Logger(ctx).Info().Msgf("created pinecone index")
-
-	return client, index, nil
-}
-
-func recordID(Key sdk.Data) string {
-	key := Key.Bytes()
-	return string(key)
-}
-
-type recordPayload struct {
-	Values       []float32    `json:"values"`
-	SparseValues sparseValues `json:"sparse_values"`
-}
-
-func (r recordPayload) PineconeSparseValues() *pinecone.SparseValues {
-	v := &pinecone.SparseValues{r.SparseValues.Indices, r.SparseValues.Values}
-	return v
+func recordID(key sdk.Data) string {
+	return string(key.Bytes())
 }
 
 type sparseValues struct {
 	Indices []uint32  `json:"indices"`
 	Values  []float32 `json:"values"`
+}
+
+type recordPayload struct {
+	Id           string       `json:"id"`
+	Values       []float32    `json:"values"`
+	SparseValues sparseValues `json:"sparse_values,omitempty"`
+}
+
+func (r recordPayload) PineconeSparseValues() *pinecone.SparseValues {
+	// the used pinecone go client needs a nil pointer when no sparse values given, or else it
+	// will throw a "Sparse vector must contain at least one value" error
+	if len(r.SparseValues.Indices) == 0 && len(r.SparseValues.Values) == 0 {
+		return nil
+	}
+
+	v := &pinecone.SparseValues{r.SparseValues.Indices, r.SparseValues.Values}
+	return v
 }
 
 func parseRecordPayload(payload sdk.Change) (parsed recordPayload, err error) {
@@ -145,7 +322,7 @@ func parseRecordPayload(payload sdk.Change) (parsed recordPayload, err error) {
 }
 
 func recordMetadata(data sdk.Metadata) (*pinecone.Metadata, error) {
-	convertedMap := make(map[string]interface{})
+	convertedMap := make(map[string]any)
 	for key, value := range data {
 		if trimmed, hasPrefix := trimPineconeKey(key); hasPrefix {
 			convertedMap[trimmed] = value

--- a/writer.go
+++ b/writer.go
@@ -79,7 +79,7 @@ func (w *Writer) Upsert(ctx context.Context, record sdk.Record) error {
 		//revive:disable-next-line
 		Id:     id,
 		Values: payload.Values,
-		// SparseValues: payload.PineconeSparseValues(),
+		SparseValues: payload.PineconeSparseValues(),
 		Metadata: metadata,
 	}
 

--- a/writer.go
+++ b/writer.go
@@ -77,10 +77,10 @@ func (w *Writer) Upsert(ctx context.Context, record sdk.Record) error {
 
 	vec := &pinecone.Vector{
 		//revive:disable-next-line
-		Id:     id,
-		Values: payload.Values,
+		Id:           id,
+		Values:       payload.Values,
 		SparseValues: payload.PineconeSparseValues(),
-		Metadata: metadata,
+		Metadata:     metadata,
 	}
 
 	_, err = w.index.UpsertVectors(&ctx, []*pinecone.Vector{vec})

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package pinecone
 
 import (


### PR DESCRIPTION
### Description

- Adds a retry loop when checking whether a pinecone vector was properly written or not. On development I observed that calling the `UpsertVectors` and then immediately the `FetchVectors` rpc calls didn't yield expected results. An exponential backoff seems to fix the issue.

Other niceties:
- adds the namespace parameter
- adds a stricter linter configuration
- enables back sparse values (disabled on development)
- setup tests on github workflows